### PR TITLE
ci: retry Run Analysis steps on transient upstream failures

### DIFF
--- a/.github/workflows/run_analysis.yml
+++ b/.github/workflows/run_analysis.yml
@@ -35,10 +35,36 @@ jobs:
         run: uv sync --frozen
 
       - name: Run get_raw_data script
-        run: uv run python -m scripts.extract_raw_data
+        env:
+          MAX_ATTEMPTS: "3"
+          RETRY_WAIT_SECONDS: "300"
+        run: |
+          attempt=1
+          until uv run python -m scripts.extract_raw_data; do
+            if [ "$attempt" -ge "$MAX_ATTEMPTS" ]; then
+              echo "::error::extract_raw_data failed after $attempt attempts"
+              exit 1
+            fi
+            echo "::warning::Attempt $attempt failed; retrying in ${RETRY_WAIT_SECONDS}s..."
+            attempt=$((attempt + 1))
+            sleep "$RETRY_WAIT_SECONDS"
+          done
 
       - name: Run charts script
-        run: uv run python -m scripts.analysis
+        env:
+          MAX_ATTEMPTS: "3"
+          RETRY_WAIT_SECONDS: "300"
+        run: |
+          attempt=1
+          until uv run python -m scripts.analysis; do
+            if [ "$attempt" -ge "$MAX_ATTEMPTS" ]; then
+              echo "::error::analysis failed after $attempt attempts"
+              exit 1
+            fi
+            echo "::warning::Attempt $attempt failed; retrying in ${RETRY_WAIT_SECONDS}s..."
+            attempt=$((attempt + 1))
+            sleep "$RETRY_WAIT_SECONDS"
+          done
 
       - name: Detect changes
         id: git_status


### PR DESCRIPTION
## Summary

- Wraps the `Run get_raw_data script` and `Run charts script` steps in `run_analysis.yml` with a retry-with-backoff loop (3 attempts, 5-minute wait between attempts).
- Recovers automatically from transient upstream API failures (WB 502/504/connection drops, IMF 500/504) and gives the `datacommons.one.org` Cloudflare 403 a second chance.
- See #25 for the full diagnosis. The root-cause fix for the Cloudflare 403 is server-side and tracked separately.

## Test plan

- [ ] Workflow YAML is syntactically valid (passes `Run Analysis` lint when triggered)
- [ ] Verify retry behaviour by triggering the workflow manually via `workflow_dispatch` once merged
- [ ] Confirm the next scheduled Monday run succeeds (or surfaces a real failure after 3 attempts)
